### PR TITLE
Add `RANTLY_COUNT` environment variable

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -331,6 +331,26 @@ property_of {
 }
 </code></pre>
 
+To control the number of property tests to generate, you have three options. In order of precedence:
+
+# Pass an integer argument to @check@
+
+<pre><code>
+property_of {
+  integer
+}.check(9000) { |i|
+  assert_kind_of Integer, i
+}
+</code></pre>
+
+#_ Set the @RANTLY_COUNT@ environment variable
+
+<pre><code>
+RANTLY_COUNT=9000 ruby my_property_test.rb
+</code></pre>
+
+#_ If neither of the above are set, the default will be to run the @check@ block 100 times.
+
 If you wish to have quiet output from Rantly, set environmental variable:
 <pre><code>
 RANTLY_VERBOSE=0 # silent

--- a/lib/rantly/property.rb
+++ b/lib/rantly/property.rb
@@ -6,6 +6,7 @@ class Rantly::Property
   attr_reader :failed_data, :shrunk_failed_data, :io
 
   VERBOSITY = ENV.fetch('RANTLY_VERBOSE'){ 1 }.to_i
+  RANTLY_COUNT = ENV.fetch('RANTLY_COUNT'){ 100 }.to_i
 
   def io
     @io ||= if VERBOSITY >= 1
@@ -23,7 +24,7 @@ class Rantly::Property
     @property = property
   end
 
-  def check(n=100,limit=10,&assertion)
+  def check(n=RANTLY_COUNT,limit=10,&assertion)
     i = 0
     test_data = nil
     begin


### PR DESCRIPTION
If this is set, `Property#check` will default to generating `RANTLY_COUNT` values. Inspiration is taken from https://github.com/justincampbell/generative#running

I find this useful as most of the time I'd like to have a small `n` with a faster test run, however every less frequently I'd like to let the tests run for a while with a relatively large `n`. Currently I'd have to edit every use of `Property#check` to do this.