### PR TITLE
Add usage example of deflated and tuple shrinking strategies for the array

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -385,8 +385,27 @@ Enable shrinking with
 require 'rantly/shrinks'
 </code></pre>
 
-Use <code>Tuple</code> class if you want an array whose elements are individually shrinked, but are not removed.
-Use <code>Deflating</code> class if you want an array whose elements are individully shrinked whenever possible, and removed otherwise.
+Use <code>Tuple</code> class if you want an array whose elements are individually shrinked, but are not removed. Example:
+
+<pre><code>
+property_of {
+  len = range(0, 10)
+  Tuple.new( array(len) { integer } )
+}.check {
+  # .. property check here ..
+}
+</code></pre>
+
+Use <code>Deflating</code> class if you want an array whose elements are individully shrinked whenever possible, and removed otherwise. Example:
+
+<pre><code>
+property_of {
+  len = range(0, 10)
+  Deflated.new( array(len) { integer } )
+}.check {
+  # .. property check here ..
+}
+</code></pre>
 
 Normal arrays or hashes are not shrinked.
 


### PR DESCRIPTION
Hi! This is a great library!

I was struggling to understand, how exactly to use these two classes. Had even to dig documentation generated by rubydoc [here](http://www.rubydoc.info/github/abargnesi/rantly/master/Deflating#initialize-instance_method).

I know that there is an example here: https://github.com/abargnesi/rantly/blob/master/examples/00-even-numbers/spec/tests.rb

I think that these usage examples should be either linked from the README, when `Tuple` and `Deflated` are mentioned, or as I did here, the examples should be included in the README, since they are short and go along with all the other examples in the README.

WDYT?

Thanks,
Oleksii