### PR TITLE
Improve the failure exception

### DIFF
--- a/lib/rantly/property.rb
+++ b/lib/rantly/property.rb
@@ -51,7 +51,7 @@ class Rantly::Property
         io.puts "minimal failed data (depth #{@depth}) is:"
         pretty_print @shrunk_failed_data
       end
-      raise boom
+      raise $!, "failure: #{i} tests, on:\n#{test_data}\n\n#{boom}\n", $@
     end
   end
 


### PR DESCRIPTION
Improve the failure exception to add the number of examples run and the failed example. :bowtie:

This should fix https://github.com/abargnesi/rantly/issues/21. It also makes the error message much more useful and we don't loose the backtrace.

An example:

Before:

![image](https://cloud.githubusercontent.com/assets/16052290/22155096/89577c16-df2e-11e6-9891-1e2ed7db3d33.png)


Now: :tada:

![image](https://cloud.githubusercontent.com/assets/16052290/22149500/7041221e-df14-11e6-92cf-4983cc0f9b68.png)



